### PR TITLE
feat: implementa opcao de busca por período histórico

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-API_KEY=
+API_KEY_QUOTE   = https://brapi.dev/api/quote/{stock_code}?token={token}
+API_KEY_HISTORY = https://brapi.dev/api/quote/{stock_code}?range={period}&interval=1d&token={token}

--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -2,20 +2,27 @@ import requests
 import json
 import dotenv
 import os
-
 dotenv.load_dotenv()
-Token = os.getenv("API_KEY");
+QUOTE_URL = os.getenv("API_KEY_QUOTE")
+HISTORY_URL = os.getenv("API_KEY_HISTORY")
 
-def get_stock_data(action_id):
+def get_stock_data(action_id, period=None):
     with open('data/index.json', 'r', encoding='utf-8') as file:
         index_data = json.load(file)
-    stock_code = index_data.get(str(action_id))
-    url = Token.format(stock_code=stock_code)
-    response = requests.get(url)
 
+    stock_code = index_data.get(str(action_id))
     if not stock_code:
         return None
-    
+
+    if period:
+        url = HISTORY_URL.format(stock_code=stock_code, period=period)
+    else:
+        url = QUOTE_URL.format(stock_code=stock_code)
+
+    response = requests.get(url)
+
     if response.status_code == 200:
         return response.json()
+    
+    print("❌ Falha ao buscar dados:", response.status_code, response.text)
     return None


### PR DESCRIPTION
Foi adicionado um novo endpoint no `.env` que será responsável por buscar quando o usuário quiser buscar por um período específico. Devido a API ser gratuita, os períodos buscados são fixos de 1 dia, 5 dias, 1 mês e 3 meses.